### PR TITLE
Make ClassOrInterface public.

### DIFF
--- a/src/symbol.ts
+++ b/src/symbol.ts
@@ -476,7 +476,6 @@ export class TypeReference {
   }
 }
 
-/** @internal */
 export class ClassOrInterface extends ObjectLikeType {
   constructorSignatures: Signature[] = [];
   callSignatures: Signature[] = [];


### PR DESCRIPTION
Interface and Class won't compile since they depend on internal class ClassOrInterface.